### PR TITLE
Fix the openai key setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ To build the app:
 npm run build
 ```
 
-To set the default OPENAI_API_TOKEN, put this in `.env`:
+To set the default OpenAI API key, put this in `.env.local`. It is important to include the `REACT_APP_` prefix for the variable to be picked up by Create React App:
 
 ```bash
-OPENAI_API_TOKEN=sk-...
+REACT_APP_OPENAI_API_KEY=sk-...
 ```
 
 See the Create React App section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.

--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import {
 } from "@automattic/big-sky-agents";
 import { useMemo, useState } from "react";
 
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_API_KEY =  process.env.REACT_APP_OPENAI_API_KEY;
 const TEMPERATURE = 0.2;
 const DEMO_AGENT_ID = "demo-agent";
 


### PR DESCRIPTION
React is strict about the dotenv var naming  https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env

They also suggest using .env.local for anything not committed to repo